### PR TITLE
Scan to pc feature

### DIFF
--- a/nav2_localization/CMakeLists.txt
+++ b/nav2_localization/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(message_filters REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(laser_geometry REQUIRED)
 
 set(dependencies
   rclcpp
@@ -31,6 +32,7 @@ set(dependencies
   tf2_ros
   tf2
   nav2_msgs
+  laser_geometry
 )
 
 include_directories(include)

--- a/nav2_localization/include/nav2_localization/dummy_particle_filter.hpp
+++ b/nav2_localization/include/nav2_localization/dummy_particle_filter.hpp
@@ -2,7 +2,7 @@
 #define NAV2_LOCALIZATION__DUMMY_PARTICLE_FILTER_HPP_
 
 #include "geometry_msgs/msg/transform_stamped.hpp"
-#include "sensor_msgs/msg/point_cloud2.h"
+#include "sensor_msgs/msg/point_cloud2.hpp"
 #include "nav2_localization/interfaces/sample_motion_model_base.hpp"
 #include "nav2_localization/interfaces/matcher2d_base.hpp"
 #include <vector>

--- a/nav2_localization/include/nav2_localization/dummy_particle_filter.hpp
+++ b/nav2_localization/include/nav2_localization/dummy_particle_filter.hpp
@@ -2,7 +2,7 @@
 #define NAV2_LOCALIZATION__DUMMY_PARTICLE_FILTER_HPP_
 
 #include "geometry_msgs/msg/transform_stamped.hpp"
-#include <sensor_msgs/PointCloud2.h>
+#include "sensor_msgs/msg/point_cloud2.h"
 #include "nav2_localization/interfaces/sample_motion_model_base.hpp"
 #include "nav2_localization/interfaces/matcher2d_base.hpp"
 #include <vector>

--- a/nav2_localization/include/nav2_localization/dummy_particle_filter.hpp
+++ b/nav2_localization/include/nav2_localization/dummy_particle_filter.hpp
@@ -2,7 +2,7 @@
 #define NAV2_LOCALIZATION__DUMMY_PARTICLE_FILTER_HPP_
 
 #include "geometry_msgs/msg/transform_stamped.hpp"
-#include "sensor_msgs/msg/laser_scan.hpp"
+#include <sensor_msgs/PointCloud2.h>
 #include "nav2_localization/interfaces/sample_motion_model_base.hpp"
 #include "nav2_localization/interfaces/matcher2d_base.hpp"
 #include <vector>
@@ -25,7 +25,7 @@ public:
         				 const geometry_msgs::msg::TransformStamped& curr_odom,
 						 const geometry_msgs::msg::TransformStamped& prev_pose);
 	void update_step(const Matcher2d::Ptr &matcher2d,
-					 const sensor_msgs::msg::LaserScan::ConstSharedPtr& laser_scan);
+					 const sensor_msgs::msg::PointCloud2::ConstSharedPtr& scan);
 	geometry_msgs::msg::TransformStamped get_most_likely_pose();
 
 private:

--- a/nav2_localization/include/nav2_localization/interfaces/matcher2d_base.hpp
+++ b/nav2_localization/include/nav2_localization/interfaces/matcher2d_base.hpp
@@ -2,7 +2,7 @@
 #define NAV2_LOCALIZATION__MATCHER2D_BASE_HPP_
 
 #include "geometry_msgs/msg/transform_stamped.hpp"
-#include "sensor_msgs/msg/point_cloud2.h"
+#include "sensor_msgs/msg/point_cloud2.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "nav2_util/lifecycle_node.hpp"

--- a/nav2_localization/include/nav2_localization/interfaces/matcher2d_base.hpp
+++ b/nav2_localization/include/nav2_localization/interfaces/matcher2d_base.hpp
@@ -2,7 +2,7 @@
 #define NAV2_LOCALIZATION__MATCHER2D_BASE_HPP_
 
 #include "geometry_msgs/msg/transform_stamped.hpp"
-#include "sensor_msgs/msg/laser_scan.hpp"
+#include <sensor_msgs/PointCloud2.h>
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "nav2_util/lifecycle_node.hpp"
@@ -28,7 +28,7 @@ public:
 	 * @param curr_pose A pose to match the scan from.
 	 * @return The probability of the robot being at curr_pose, given scan
 	 */
-	virtual double getScanProbability(const sensor_msgs::msg::LaserScan::ConstSharedPtr &scan,
+	virtual double getScanProbability(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &scan,
 									  const geometry_msgs::msg::TransformStamped &curr_pose) = 0;
 
 	/**

--- a/nav2_localization/include/nav2_localization/interfaces/matcher2d_base.hpp
+++ b/nav2_localization/include/nav2_localization/interfaces/matcher2d_base.hpp
@@ -2,7 +2,7 @@
 #define NAV2_LOCALIZATION__MATCHER2D_BASE_HPP_
 
 #include "geometry_msgs/msg/transform_stamped.hpp"
-#include <sensor_msgs/PointCloud2.h>
+#include "sensor_msgs/msg/point_cloud2.h"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "nav2_util/lifecycle_node.hpp"

--- a/nav2_localization/include/nav2_localization/interfaces/solver_base.hpp
+++ b/nav2_localization/include/nav2_localization/interfaces/solver_base.hpp
@@ -37,7 +37,7 @@ public:
      */
 	virtual geometry_msgs::msg::TransformStamped solve(
 		const geometry_msgs::msg::TransformStamped& curr_odom,
-		const sensor_msgs::msg::Pointcloud2::ConstSharedPtr& scan) = 0;
+		const sensor_msgs::msg::PointCloud2::ConstSharedPtr& scan) = 0;
 
 	/**
 	 * @brief Initializes the filter being used with a given pose

--- a/nav2_localization/include/nav2_localization/interfaces/solver_base.hpp
+++ b/nav2_localization/include/nav2_localization/interfaces/solver_base.hpp
@@ -9,7 +9,7 @@
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
-#include "sensor_msgs/msg/point_cloud2.h"
+#include "sensor_msgs/msg/point_cloud2.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 
 // Others

--- a/nav2_localization/include/nav2_localization/interfaces/solver_base.hpp
+++ b/nav2_localization/include/nav2_localization/interfaces/solver_base.hpp
@@ -9,7 +9,7 @@
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
-#include <sensor_msgs/PointCloud2.h>
+#include "sensor_msgs/msg/point_cloud2.h"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 
 // Others

--- a/nav2_localization/include/nav2_localization/interfaces/solver_base.hpp
+++ b/nav2_localization/include/nav2_localization/interfaces/solver_base.hpp
@@ -9,7 +9,7 @@
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
-#include "sensor_msgs/msg/laser_scan.hpp"
+#include <sensor_msgs/PointCloud2.h>
 #include "nav_msgs/msg/occupancy_grid.hpp"
 
 // Others
@@ -37,7 +37,7 @@ public:
      */
 	virtual geometry_msgs::msg::TransformStamped solve(
 		const geometry_msgs::msg::TransformStamped& curr_odom,
-		const sensor_msgs::msg::LaserScan::ConstSharedPtr& laser_scan) = 0;
+		const sensor_msgs::msg::Pointcloud2::ConstSharedPtr& scan) = 0;
 
 	/**
 	 * @brief Initializes the filter being used with a given pose

--- a/nav2_localization/include/nav2_localization/nav2_localization.hpp
+++ b/nav2_localization/include/nav2_localization/nav2_localization.hpp
@@ -11,7 +11,7 @@
 #include "nav2_localization/interfaces/solver_base.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "message_filters/subscriber.h"
-#include "sensor_msgs/msg/laser_scan.hpp"
+#include <sensor_msgs/PointCloud2.h>
 #include "tf2_ros/message_filter.h"
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
@@ -85,7 +85,7 @@ protected:
     void initTransforms();
 
     /**
-     * @brief Initializes the laser scan message filter
+     * @brief Initializes the scan message filter
      */
     void initMessageFilters();
     
@@ -101,10 +101,10 @@ protected:
     void mapReceived(const nav_msgs::msg::OccupancyGrid::SharedPtr msg);
 
     /**
-     * @brief Callback when the laser is received
-     * @param laser_scan pointer to the received laser message
+     * @brief Callback when the scan is received
+     * @param scan pointer to the received PointCloud2 message
      */
-    void laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan);
+    void scanReceived(sensor_msgs::msg::PointCloud2::ConstSharedPtr scan);
 
     /**
      * @brief Callback when the initial pose of the robot is received
@@ -116,7 +116,7 @@ protected:
     rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::ConstSharedPtr map_sub_;
     bool first_map_received_{false};
 
-    // Laser scan
+    // Scan
     std::string scan_topic_;
 
     // Transforms
@@ -129,9 +129,9 @@ protected:
     tf2::Duration transform_tolerance_;
 
     // Message filters
-    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::LaserScan>> laser_scan_sub_;
-    std::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>> laser_scan_filter_;
-    message_filters::Connection laser_scan_connection_;
+    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::PointCloud2>> scan_sub_;
+    std::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::msg::PointCloud2>> scan_filter_;
+    message_filters::Connection scan_connection_;
 
     // Sample Motion Model Plugin
     pluginlib::ClassLoader<nav2_localization::SampleMotionModel> sample_motion_model_loader_;

--- a/nav2_localization/include/nav2_localization/nav2_localization.hpp
+++ b/nav2_localization/include/nav2_localization/nav2_localization.hpp
@@ -11,7 +11,7 @@
 #include "nav2_localization/interfaces/solver_base.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "message_filters/subscriber.h"
-#include "sensor_msgs/msg/point_cloud2.h"
+#include "sensor_msgs/msg/point_cloud2.hpp"
 #include "tf2_ros/message_filter.h"
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"

--- a/nav2_localization/include/nav2_localization/nav2_localization.hpp
+++ b/nav2_localization/include/nav2_localization/nav2_localization.hpp
@@ -11,7 +11,7 @@
 #include "nav2_localization/interfaces/solver_base.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "message_filters/subscriber.h"
-#include <sensor_msgs/PointCloud2.h>
+#include "sensor_msgs/msg/point_cloud2.h"
 #include "tf2_ros/message_filter.h"
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"

--- a/nav2_localization/include/nav2_localization/nav2_localization.hpp
+++ b/nav2_localization/include/nav2_localization/nav2_localization.hpp
@@ -11,12 +11,15 @@
 #include "nav2_localization/interfaces/solver_base.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "message_filters/subscriber.h"
+#include "sensor_msgs/msg/laser_scan.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "tf2_ros/message_filter.h"
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
+#include "laser_geometry/laser_geometry.hpp"
+
 
 namespace nav2_localization
 {
@@ -101,6 +104,12 @@ protected:
     void mapReceived(const nav_msgs::msg::OccupancyGrid::SharedPtr msg);
 
     /**
+     * @brief Callback when a LaserScan is received. It will convert it to a PC and use the callback for generic scans
+     * @param scan pointer to the received LaserScan message
+     */
+    void laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan);
+
+    /**
      * @brief Callback when the scan is received
      * @param scan pointer to the received PointCloud2 message
      */
@@ -129,9 +138,13 @@ protected:
     tf2::Duration transform_tolerance_;
 
     // Message filters
+    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::LaserScan>> laser_scan_sub_;
     std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::PointCloud2>> scan_sub_;
+    std::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>> laser_scan_filter_;
     std::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::msg::PointCloud2>> scan_filter_;
+    message_filters::Connection laser_scan_connection_;
     message_filters::Connection scan_connection_;
+	laser_geometry::LaserProjection laser_to_pc_projector_;
 
     // Sample Motion Model Plugin
     pluginlib::ClassLoader<nav2_localization::SampleMotionModel> sample_motion_model_loader_;

--- a/nav2_localization/include/nav2_localization/plugins/matcher2d_plugins.hpp
+++ b/nav2_localization/include/nav2_localization/plugins/matcher2d_plugins.hpp
@@ -12,7 +12,7 @@ class LikelihoodFieldMatcher2d : public Matcher2d
 public:
 	LikelihoodFieldMatcher2d() : Matcher2d(){}
 
-	double getScanProbability(const sensor_msgs::msg::LaserScan::ConstSharedPtr& scan,
+	double getScanProbability(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& scan,
 							  const geometry_msgs::msg::TransformStamped &curr_pose) override;
 	void setMap(const nav_msgs::msg::OccupancyGrid::SharedPtr &map) override;
 	void setSensorPose(const geometry_msgs::msg::TransformStamped &sensor_pose) override;

--- a/nav2_localization/include/nav2_localization/plugins/solver_plugins.hpp
+++ b/nav2_localization/include/nav2_localization/plugins/solver_plugins.hpp
@@ -9,7 +9,6 @@
 // Types
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
-#include <sensor_msgs/PointCloud2.h>
 #include "nav_msgs/msg/occupancy_grid.hpp"
 
 // Others

--- a/nav2_localization/include/nav2_localization/plugins/solver_plugins.hpp
+++ b/nav2_localization/include/nav2_localization/plugins/solver_plugins.hpp
@@ -9,7 +9,7 @@
 // Types
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
-#include "sensor_msgs/msg/laser_scan.hpp"
+#include <sensor_msgs/PointCloud2.h>
 #include "nav_msgs/msg/occupancy_grid.hpp"
 
 // Others
@@ -25,7 +25,7 @@ public:
 
 	geometry_msgs::msg::TransformStamped solve(
 		const geometry_msgs::msg::TransformStamped& curr_odom,
-		const sensor_msgs::msg::LaserScan::ConstSharedPtr& laser_scan) override;
+		const sensor_msgs::msg::PointCloud2::ConstSharedPtr& scan) override;
 
 	void initFilter(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr &pose) override;
 

--- a/nav2_localization/package.xml
+++ b/nav2_localization/package.xml
@@ -21,6 +21,7 @@
   <depend>sensor_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>laser_geometry</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/nav2_localization/src/dummy_particle_filter.cpp
+++ b/nav2_localization/src/dummy_particle_filter.cpp
@@ -13,7 +13,7 @@ void DummyParticleFilter::prediction_step(const SampleMotionModel::Ptr &motion_s
 {}
 
 void DummyParticleFilter::update_step(const Matcher2d::Ptr &matcher2d,
-									  const sensor_msgs::msg::LaserScan::ConstSharedPtr& laser_scan)
+									  const sensor_msgs::msg::PointCloud2::ConstSharedPtr& scan)
 {}
 
 geometry_msgs::msg::TransformStamped DummyParticleFilter::get_most_likely_pose()

--- a/nav2_localization/src/plugins/matcher2d.cpp
+++ b/nav2_localization/src/plugins/matcher2d.cpp
@@ -4,6 +4,7 @@
 #include "nav2_localization/map_utils.hpp"
 #include "tf2/utils.h"
 #include <sensor_msgs/point_cloud_conversion.h>
+#include <sensor_msgs/PointCloud.h>
 
 namespace nav2_localization
 {

--- a/nav2_localization/src/plugins/matcher2d.cpp
+++ b/nav2_localization/src/plugins/matcher2d.cpp
@@ -3,8 +3,8 @@
 #include "nav2_localization/plugins/matcher2d_plugins.hpp"
 #include "nav2_localization/map_utils.hpp"
 #include "tf2/utils.h"
-#include <sensor_msgs/point_cloud_conversion.h>
-#include <sensor_msgs/PointCloud.h>
+#include "sensor_msgs/point_cloud_conversion.hpp"
+#include "sensor_msgs/msg/point_cloud.h"
 
 namespace nav2_localization
 {

--- a/nav2_localization/src/plugins/matcher2d.cpp
+++ b/nav2_localization/src/plugins/matcher2d.cpp
@@ -4,7 +4,7 @@
 #include "nav2_localization/map_utils.hpp"
 #include "tf2/utils.h"
 #include "sensor_msgs/point_cloud_conversion.hpp"
-#include "sensor_msgs/msg/point_cloud.h"
+#include "sensor_msgs/msg/point_cloud.hpp"
 
 namespace nav2_localization
 {

--- a/nav2_localization/src/plugins/matcher2d.cpp
+++ b/nav2_localization/src/plugins/matcher2d.cpp
@@ -5,7 +5,7 @@
 #include "tf2/utils.h"
 #include "sensor_msgs/point_cloud_conversion.hpp"
 #include "sensor_msgs/msg/point_cloud.hpp"
-#include <math.h> // To use "pow()" and "atan2()"
+#include <math.h> // To use "hypot()" and "atan2()"
 
 namespace nav2_localization
 {
@@ -50,7 +50,7 @@ double LikelihoodFieldMatcher2d::getScanProbability(
  
 		if(point.z == 0)
 		{
-			distance = sqrt(pow(point.x, 2) + pow(point.y, 2));
+			distance = hypot(point.x, point.y);
 			angle = atan2(point.x, point.y+1e-10); // atan(x/y)
 			
 			ranges.push_back(distance);
@@ -66,7 +66,7 @@ double LikelihoodFieldMatcher2d::getScanProbability(
 	}
 
 	// Get most distant measurement (taken as max range
-	double z_max = max_element(ranges.begin(), ranges.end()) - ranges.begin();
+	double z_max = *max_element(ranges.begin(), ranges.end());
 
 	double q = 1;	// Probability of curr_pose given scan
 	double theta = tf2::getYaw(curr_pose.transform.rotation); // Robot's orientation

--- a/nav2_localization/src/plugins/solver.cpp
+++ b/nav2_localization/src/plugins/solver.cpp
@@ -8,14 +8,14 @@ namespace nav2_localization
 {
 geometry_msgs::msg::TransformStamped DummySolver2d::solve(
 	const geometry_msgs::msg::TransformStamped& curr_odom,
-	const sensor_msgs::msg::LaserScan::ConstSharedPtr& laser_scan)
+	const sensor_msgs::msg::PointCloud2::ConstSharedPtr& scan)
 {
 	// Motion update
 	pf_->prediction_step(motionSampler_, curr_odom, prev_odom_, prev_pose_);
 	prev_odom_ = curr_odom;
 
 	// Measurement update
-	pf_->update_step(matcher_, laser_scan);
+	pf_->update_step(matcher_, scan);
 
 	geometry_msgs::msg::TransformStamped curr_pose = pf_->get_most_likely_pose();
 	prev_pose_ = curr_pose;


### PR DESCRIPTION
Support both LaserScan and PC2 message types as input measurements. LaserScan msgs will be transformed into a PC2 and used as a PC2 scan.